### PR TITLE
Improve blog post responsiveness on mobile

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -27,7 +27,7 @@ const { Content } = await post.render();
     description={description}
     image={ogUrl}
 >
-    <SectionContainer class="wrap wrap-px grid gap-8 px-4 sm:gap-16 sm:px-8">
+    <SectionContainer class="wrap wrap-px flex justify-center px-4 sm:gap-16 sm:px-8">
         <div class="flex mt-32">
             <div class="content--container flex-1 md:pr-6">
                 <article

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -28,8 +28,8 @@ const { Content } = await post.render();
     image={ogUrl}
 >
     <SectionContainer class="wrap wrap-px flex justify-center px-4 sm:gap-16 sm:px-8">
-        <div class="flex mt-32">
-            <div class="content--container flex-1 md:pr-6">
+        <div class="flex mt-32 w-full">
+            <div class="content--container flex-1 md:pr-6 w-full">
                 <article
                     class="mx-auto prose prose-neutral prose-headings:font-medium prose-h1:text-4xl prose-h2:text-3xl prose-h3:text-2xl prose-h4:text-xl prose-h5:text-lg prose-h6:text-base prose-h2:scroll-mt-4 prose-h3:scroll-mt-4 prose-h4:scroll-mt-4 prose-h5:scroll-mt-4 prose-h6:scroll-mt-4 prose-headings:my-8"
                 >


### PR DESCRIPTION
For some blog posts such as https://www.astro-lane.avenuelabs.co/blog/adding-new-post (I suspect due to the long code blocks), the posts aren't responsive on mobile.

![image](https://github.com/christian-luntok/astro-lane/assets/90932525/be074ee9-befc-4720-a96d-5f55a899ae9a)

This fix does get rid of the `gap-8` class, but since the container only has one child anyway, the style remains the same.

Comparison fix:

![image](https://github.com/christian-luntok/astro-lane/assets/90932525/1a6e9189-6f2b-42d6-a89a-12d032f92ddb)
